### PR TITLE
Return directly app url on successfull response

### DIFF
--- a/lib/fastlane/plugin/browserstack/helper/browserstack_helper.rb
+++ b/lib/fastlane/plugin/browserstack/helper/browserstack_helper.rb
@@ -44,12 +44,7 @@ module Fastlane
           )
 
           response_json = JSON.parse(response.to_s)
-
-          if !response_json["custom_id"].nil?
-            return response_json["custom_id"]
-          else
-            return response_json["app_url"]
-          end
+          return response_json["app_url"]
         rescue RestClient::ExceptionWithResponse => err
           begin
             error_response = JSON.parse(err.response.to_s)["error"]


### PR DESCRIPTION
File upload should return app_url instead of custom_id

Resolves following issue:
https://github.com/browserstack/browserstack-fastlane-plugin/issues/19