### PR TITLE
Add ios keychain support param

### DIFF
--- a/lib/fastlane/plugin/browserstack/actions/upload_to_browserstack_app_automate_action.rb
+++ b/lib/fastlane/plugin/browserstack/actions/upload_to_browserstack_app_automate_action.rb
@@ -122,7 +122,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: default_file_path),
           FastlaneCore::ConfigItem.new(key: :ios_keychain_support,
-                                       description: "ios_keychain_support",
+                                       description: "Enable/disable support for iOS keychain",
                                        optional: true,
                                        is_string: true)
         ]

--- a/lib/fastlane/plugin/browserstack/actions/upload_to_browserstack_app_automate_action.rb
+++ b/lib/fastlane/plugin/browserstack/actions/upload_to_browserstack_app_automate_action.rb
@@ -16,12 +16,14 @@ module Fastlane
         browserstack_access_key = params[:browserstack_access_key] # Required
         custom_id = params[:custom_id]
         file_path = params[:file_path].to_s # Required
+        ios_keychain_support = params[:ios_keychain_support]
 
         validate_file_path(file_path)
+        validate_ios_keychain_support(ios_keychain_support) unless ios_keychain_support.nil?
 
         UI.message("Uploading app to BrowserStack AppAutomate...")
 
-        browserstack_app_id = Helper::BrowserstackHelper.upload_file(browserstack_username, browserstack_access_key, file_path, UPLOAD_API_ENDPOINT, custom_id)
+        browserstack_app_id = Helper::BrowserstackHelper.upload_file(browserstack_username, browserstack_access_key, file_path, UPLOAD_API_ENDPOINT, custom_id, ios_keychain_support)
 
         # Set 'BROWSERSTACK_APP_ID' environment variable, if app upload was successful.
         ENV['BROWSERSTACK_APP_ID'] = browserstack_app_id
@@ -42,6 +44,19 @@ module Fastlane
         file_path_parts = file_path.split(".")
         unless file_path_parts.length > 1 && SUPPORTED_FILE_EXTENSIONS.include?(file_path_parts.last)
           UI.user_error!("file_path is invalid, only files with extensions " + SUPPORTED_FILE_EXTENSIONS.to_s + " are allowed to be uploaded.")
+        end
+      end
+
+      # Validate ios_keychain_support
+      def self.validate_ios_keychain_support(ios_keychain_support)
+        platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        if !platform.nil? && platform != :ios
+          # Check if platform is specified and not ios
+          # If so, then raise error.
+          UI.user_error!("ios_keychain_support param can only be used with platform ios")
+        end
+        unless ['true', 'false'].include?(ios_keychain_support.to_s)
+          UI.user_error!("ios_keychain_support should be either 'true' or 'false'.")
         end
       end
 
@@ -105,7 +120,11 @@ module Fastlane
                                        description: "Path to the app file",
                                        optional: true,
                                        is_string: true,
-                                       default_value: default_file_path)
+                                       default_value: default_file_path),
+          FastlaneCore::ConfigItem.new(key: :ios_keychain_support,
+                                       description: "ios_keychain_support",
+                                       optional: true,
+                                       is_string: true)
         ]
       end
 

--- a/lib/fastlane/plugin/browserstack/helper/browserstack_helper.rb
+++ b/lib/fastlane/plugin/browserstack/helper/browserstack_helper.rb
@@ -20,7 +20,7 @@ module Fastlane
       # +custom_id+:: Custom id for app upload.
       # +file_path+:: Path to the file to be uploaded.
       # +url+:: BrowserStack's app upload endpoint.
-      def self.upload_file(browserstack_username, browserstack_access_key, file_path, url, custom_id = nil)
+      def self.upload_file(browserstack_username, browserstack_access_key, file_path, url, custom_id = nil, ios_keychain_support = nil)
         payload = {
           multipart: true,
           file: File.new(file_path, 'rb')
@@ -28,6 +28,10 @@ module Fastlane
 
         unless custom_id.nil?
           payload[:data] = '{ "custom_id": "' + custom_id + '" }'
+        end
+
+        unless ios_keychain_support.nil?
+          payload[:ios_keychain_support] = ios_keychain_support
         end
 
         headers = {

--- a/lib/fastlane/plugin/browserstack/version.rb
+++ b/lib/fastlane/plugin/browserstack/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Browserstack
-    VERSION = "0.3.3"
+    VERSION = "0.3.4"
   end
 end

--- a/spec/upload_to_browserstack_app_automate_action_spec.rb
+++ b/spec/upload_to_browserstack_app_automate_action_spec.rb
@@ -146,5 +146,26 @@ describe Fastlane::Actions::UploadToBrowserstackAppAutomateAction do
         end").runner.execute(:test)
       expect(ENV['BROWSERSTACK_APP_ID']).to eq(custom_id)
     end
+
+    it "should work with ios keychain support" do
+      ENV['BROWSERSTACK_APP_ID'] = nil
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH] = nil
+
+      expect(RestClient::Request).to receive(:execute).and_return({ "app_url" => "bs://app_url", "ios_keychain_support" => true }.to_json)
+      fastfile = Fastlane::FastFile.new.parse("
+        platform :ios do
+          lane :test do
+            upload_to_browserstack_app_automate({
+              browserstack_username: 'username',
+              browserstack_access_key: 'access_key',
+              ios_keychain_support: 'true',
+              file_path: File.join(FIXTURE_PATH, 'HelloWorld.apk')
+            })
+          end
+        end
+      ")
+      fastfile.runner.execute(:test, :ios)
+      expect(ENV['BROWSERSTACK_APP_ID']).to eq("bs://app_url")
+    end
   end
 end

--- a/spec/upload_to_browserstack_app_automate_action_spec.rb
+++ b/spec/upload_to_browserstack_app_automate_action_spec.rb
@@ -159,7 +159,7 @@ describe Fastlane::Actions::UploadToBrowserstackAppAutomateAction do
               browserstack_username: 'username',
               browserstack_access_key: 'access_key',
               ios_keychain_support: 'true',
-              file_path: File.join(FIXTURE_PATH, 'HelloWorld.apk')
+              file_path: File.join(FIXTURE_PATH, 'HelloWorld.ipa')
             })
           end
         end

--- a/spec/upload_to_browserstack_app_automate_action_spec.rb
+++ b/spec/upload_to_browserstack_app_automate_action_spec.rb
@@ -150,7 +150,6 @@ describe Fastlane::Actions::UploadToBrowserstackAppAutomateAction do
     it "should work with ios keychain support" do
       ENV['BROWSERSTACK_APP_ID'] = nil
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH] = nil
-
       expect(RestClient::Request).to receive(:execute).and_return({ "app_url" => "bs://app_url", "ios_keychain_support" => true }.to_json)
       fastfile = Fastlane::FastFile.new.parse("
         platform :ios do


### PR DESCRIPTION
- this param is used to enable/disable ios keychain support
- if you want to enable keychain support, set this param to true